### PR TITLE
Adding events (dogodki) to Ogrodje home page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "Ogrodje Site Build"
 on:
   push:
     branches: [ master ]
-  
+
   pull_request:
     branches: [ master ]
 
@@ -22,11 +22,12 @@ jobs:
     name: "Build & Deploy"
     environment: ci
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 21 
+          node-version: 21
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -35,4 +36,4 @@ jobs:
           netlify deploy \
             --site $NETLIFY_SITE_ID \
             --auth $NETLIFY_AUTH_TOKEN \
-            --prod      
+            --prod

--- a/src/model/Meetup.ts
+++ b/src/model/Meetup.ts
@@ -1,0 +1,18 @@
+import slugify from "@sindresorhus/slugify";
+
+export interface Meetup {
+  id: string,
+  name: string,
+
+  homePageUrl?: string,
+  meetupUrl?: string,
+  discordUrl?: string,
+  linkedInUrl?: string,
+}
+
+export const meetupPath = (meetup: Meetup) =>
+  slugify(meetup.name)
+
+export interface MeetupEvent {
+  name: String
+}

--- a/src/pages/dogodki.astro
+++ b/src/pages/dogodki.astro
@@ -1,0 +1,28 @@
+---
+import Layout from "../layouts/Layout.astro";
+import {MeetupService} from "../services/MeetupService";
+
+
+const meetups = await MeetupService.allMeetups();
+
+console.log(meetups);
+---
+<Layout title="Dogodki" hideFooter={"true"}>
+  <h1>Dogodki</h1>
+
+
+  <div>
+    {meetups.map(meetupData => {
+      const [meetup, events] = meetupData;
+
+      return (
+        <div class="name">{meetup.name}</div>
+        <div class="events">
+          {events.map(event => (
+            <div>event {event.name}</div>
+          ))}
+        </div>
+      )
+    })}
+  </div>
+</Layout>

--- a/src/services/EpisodeService.ts
+++ b/src/services/EpisodeService.ts
@@ -39,7 +39,10 @@ export class EpisodeService extends HyGraphService {
     spotifyUrl
   `
 
-  public static async publishedEpisodes(size: number = 200, stage: Stage = Stage.Published): Promise<Array<Episode>> {
+  public static async publishedEpisodes(
+    size: number = 200,
+    stage: Stage = Stage.Published
+  ): Promise<Array<Episode>> {
     return this.query(`
       query PublishedEpisodes($size: Int, $stage: Stage!) {
         episodes(first: $size, orderBy: airedAt_DESC, stage: $stage) {

--- a/src/services/MeetupService.ts
+++ b/src/services/MeetupService.ts
@@ -1,0 +1,37 @@
+import {HyGraphService} from "./HyGraphService.ts";
+import type {Meetup, MeetupEvent} from "../model/Meetup.ts";
+
+export class MeetupService extends HyGraphService {
+  private static fields: string = `
+    id
+    name
+    homePageUrl
+    meetupUrl
+    discordUrl
+    linkedInUrl
+  `
+
+  public static async allMeetups(): Promise<[Meetup, MeetupEvent[]][]> {
+    return this.query(`
+      query AllMeetups($size: Int) {
+        meetups(first: $size) {
+          ${this.fields}
+        }
+      }
+    `)
+      .then(data => data.meetups as Array<Meetup>)
+      .then(meetups => meetups.map(meetup => this.collectEvents(meetup)))
+  }
+
+  private static collectEvents(meetup: Meetup): [Meetup, MeetupEvent[]] {
+    let events: MeetupEvent[] = []
+    if (meetup.meetupUrl) events.push(...this.collectFromMeetup(meetup.meetupUrl))
+    return [meetup, events]
+  }
+
+  private static collectFromMeetup(url: String): MeetupEvent[] {
+    console.log(`Collecting events from ${url}`)
+    // TODO: Continue here.
+    return []
+  }
+}


### PR DESCRIPTION
With this experimental work, we would like to introduce `/dogodki` to the Ogrodje homepage. 

The page should aggregate all the events from a given set of Meetups in the region, focusing on upcoming events and their respectful locations, dates and times.

The meetups are sourced from our HyGraph / GraphQL database and the list of events will be build daily on our GitHub Actions powered CI.