### PR TITLE
fix: theme toggle position on smaller screens and event icon alignment on events page 

### DIFF
--- a/src/components/EventRow.astro
+++ b/src/components/EventRow.astro
@@ -64,8 +64,8 @@ const eventClasses = (e: Event): string => {
             <Image
               src={event.meetup.logoImage}
               title={event.meetupName}
-              width={100}
-              height={100}
+              width={33}
+              height={33}
               alt={meetupNameAlt(event)}
             />
           </div>
@@ -151,25 +151,22 @@ const eventClasses = (e: Event): string => {
 
         &.has_logo {
           padding-left: 0;
-          position: relative;
+          display: flex;
+          gap: 10px;
+          align-items: center;
 
           .meetup-logo {
-            position: absolute;
-            top: 0;
-            left: 0;
-            height: 100%;
             display: flex;
-            align-items: flex-start;
+            align-items: center;
+            min-width: min-content;
 
             img {
-              width: 100%;
-              height: 100%;
-              object-fit: contain;
+              object-fit: fill;
             }
           }
 
           .name {
-            margin-left: 40px;
+            flex: 7;
           }
         }
       }

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -41,6 +41,7 @@
     cursor: pointer;
     color: #6a676c;
     --toggle-duration: 500ms;
+    padding-inline: 0;
   }
 
   .theme-toggle.theme-toggle--reversed .theme-toggle__classic {


### PR DESCRIPTION
### Description
This PR introduces the following changes:

Added: ThemeToggle.astro component to allow users to toggle between light and dark modes.

Implemented: Light theme styles across the application for consistent theming.

### Details:
Removed the paddings and margins on ThemeToggle, so that it fits the screen. 
For the events page, I have used flex-box instead of absolute positioning of image, as on FRI, and other events with long names the overlapping with text starting happening.

### Screenshots of problems
![image](https://github.com/user-attachments/assets/ae118ab7-7ec9-4853-85c8-f53029b81813)
![image](https://github.com/user-attachments/assets/2cf6d134-62da-49df-a7c3-e408cc5a2dc1)

### After applied fixes
![image](https://github.com/user-attachments/assets/41aa02d7-75f1-4fca-953e-e3ddb45d6385)
![image](https://github.com/user-attachments/assets/2fc7d1cd-15ae-4617-a1d4-0eb945dca080)


Next Steps:
- probably better icon for FERI, as its hard to make responsive alignment with it. Green border around it on smaller screens due to its resolution. 

![image](https://github.com/user-attachments/assets/d38978ba-2545-48a1-8227-f2dacdec2f68)
